### PR TITLE
Clarify Font Size Options

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -157,9 +157,9 @@
         <item>20</item>
     </string-array>
     <string-array name="pref_fontSize_entries">
-        <item>small</item>
-        <item>medium</item>
-        <item>large</item>
+        <item>Smaller</item>
+        <item>Normal</item>
+        <item>Larger</item>
     </string-array>
     <string-array name="pref_fontSize_values">
         <item>1</item>


### PR DESCRIPTION
Clarify font size options and fix case to match other preference
settings.

Other settings have inital capitalization (for Color Map, FFT 
Line type, orientation, etc) so change Font Size values to match.
